### PR TITLE
[IMP][ZPL] option to not merge Zpl file 

### DIFF
--- a/delivery_carrier_label_batch/data/ir.config_parameter.xml
+++ b/delivery_carrier_label_batch/data/ir.config_parameter.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
-    <data>
+    <data noupdate="1">
         <record id="zpl2_assembler_single_images" model="ir.config_parameter">
             <field name="key">zpl2.assembler.single.images</field>
             <field name="value">False</field>
         </record>
+        <record id="zpl2_batch_merge" model="ir.config_parameter">
+            <field name="key">zpl2.batch.merge</field>
+            <field name="value">False</field>
+        </record>
+
     </data>
 </openerp>


### PR DESCRIPTION
* Purpose
if we print a large file (hundred of labels) in one single file, printer failed to print it.
So if option is set, we will generate on file per label and print it independentely